### PR TITLE
Bug 1846333: Handle pods from other kinds properly (#28)

### DIFF
--- a/deployments/auth.yaml
+++ b/deployments/auth.yaml
@@ -35,7 +35,13 @@ rules:
 - apiGroups:
   - ""
   - k8s.cni.cncf.io
+  - extensions
+  - apps
   resources:
+  - replicationcontrollers
+  - replicasets
+  - daemonsets
+  - statefulsets
   - pods
   - network-attachment-definitions
   verbs:


### PR DESCRIPTION
* Handle pods properly from deployment, daemonset or statefulset

This commit makes sure appropriate namespace is retrieved from
pod's replicaset/daemonset/replicaset incase if its deployed
using other kinds.
It would enable network-resources-injector to look for network-
attachment-definition object from the correct namespace.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

* Add check for replicationcontroller pod

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

* Use switch case instead of if-else logic

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>