### PR TITLE
Dockerfile: bump build image to golang:1.21-alpine (release-4.15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18.3-alpine as builder
+FROM golang:1.21-alpine as builder
 COPY . /usr/src/network-resources-injector
 WORKDIR /usr/src/network-resources-injector
 RUN apk add --update --virtual build-dependencies build-base bash && \


### PR DESCRIPTION
The build image of the Dockerfile was also bumped in upstream/4.16 with commit 386d174a978f ('Bump golang 1.21 to k8s 1.28.3').

Without this, build fails. The problem was introduced by commit bbb31269474d ('remove dependency elazarl/goproxy').
```
    $ podman build -t foo -f Dockerfile
    [1/2] STEP 1/4: FROM golang:1.18.3-alpine AS builder
    [1/2] STEP 2/4: COPY . /usr/src/network-resources-injector
    --> 7962c7daf633
    [1/2] STEP 3/4: WORKDIR /usr/src/network-resources-injector
    --> d2a474e16f23
    [1/2] STEP 4/4: RUN apk add --update --virtual build-dependencies build-base bash &&     make
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
    (1/25) Upgrading musl (1.2.3-r0 -> 1.2.3-r3)
    ...
    (24/25) Installing bash (5.1.16-r2)
    Executing bash-5.1.16-r2.post-install
    (25/25) Installing build-dependencies (20240613.111435)
    Executing busybox-1.35.0-r13.trigger
    OK: 189 MiB in 39 packages
    scripts/build.sh
    # k8s.io/kube-openapi/pkg/cached
    vendor/k8s.io/kube-openapi/pkg/cached/cache.go:285:16: undefined: atomic.Pointer
    vendor/k8s.io/kube-openapi/pkg/cached/cache.go:286:16: undefined: atomic.Pointer
    note: module requires Go 1.19
    make: *** [Makefile:18: default] Error 2
    Error: building at STEP "RUN apk add --update --virtual build-dependencies build-base bash &&     make": while running runtime: exit status 2
```