### PR TITLE
[th/dockerfile-go-1.22] Dockerfile: bump build dependency for upstream Dockerfile to go 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 COPY . /usr/src/network-resources-injector
 WORKDIR /usr/src/network-resources-injector
 RUN apk add --update --virtual build-dependencies build-base bash && \


### PR DESCRIPTION
Upstream's Dockerfile still uses golang:1.21-alpine as build image, and it works. However, it no longer works for downstream because 1.22 is required now.

Bump the version in the upstream Dockerfile. This fixes the build error:
```
  $ podman build -t foo -f Dockerfile .
  [1/2] STEP 1/4: FROM golang:1.21-alpine AS builder
  [1/2] STEP 2/4: COPY . /usr/src/network-resources-injector
  --> 142dfed9d62f
  [1/2] STEP 3/4: WORKDIR /usr/src/network-resources-injector
  --> 289897aa348a
  [1/2] STEP 4/4: RUN apk add --update --virtual build-dependencies
  build-base bash &&     make
  fetch
  https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
  fetch
  https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
  (1/26) Installing libgcc (13.2.1_git20240309-r0)
  ...
  (25/26) Installing bash (5.2.26-r0)
  Executing bash-5.2.26-r0.post-install
  (26/26) Installing build-dependencies (20240617.073223)
  Executing busybox-1.36.1-r28.trigger
  OK: 227 MiB in 41 packages
  scripts/build.sh
  go: go.mod requires go >= 1.22 (running go 1.21.11; GOTOOLCHAIN=local)
  make: *** [Makefile:18: default] Error 1
  Error: building at STEP "RUN apk add --update --virtual
  build-dependencies build-base bash &&     make": while running runtime:
  exit status 2
```
Fixes: bbb31269474d ('remove dependency elazarl/goproxy')