### PR TITLE
Add ocp-sustaining team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ reviewers:
   - bn222
   - wizhaoredhat
   - SchSeba
+  - yash2189
+  - kunalmemane
 approvers:
   - zshi-redhat
   - dougbtv
@@ -22,5 +24,7 @@ approvers:
   - bn222
   - wizhaoredhat
   - SchSeba
+  - yash2189
+  - kunalmemane
 component: "Networking"
 subcomponent: "SR-IOV"


### PR DESCRIPTION
Add yash and kunal from ocp-sustaining team to OWNERS for having permissions to review/approve EUS releases related PRs