### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -90,10 +89,10 @@ func generateCACertificate() (*local.Signer, []byte, error) {
 }
 
 func writeToFile(certificate, key []byte, certFilename, keyFilename string) error {
-	if err := ioutil.WriteFile("/etc/tls/"+certFilename, certificate, 0400); err != nil {
+	if err := os.WriteFile("/etc/tls/"+certFilename, certificate, 0400); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile("/etc/tls/"+keyFilename, key, 0400); err != nil {
+	if err := os.WriteFile("/etc/tls/"+keyFilename, key, 0400); err != nil {
 		return err
 	}
 	return nil
@@ -376,4 +375,3 @@ func writeCertDetailsFromSecret() (bool, error) {
 	glog.Info("Certificate details written to file")
 	return true, nil
 }
-

--- a/pkg/webhook/tlsutils.go
+++ b/pkg/webhook/tlsutils.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/golang/glog"
@@ -83,7 +83,7 @@ func NewTlsKeypairReloader(certPath, keyPath string) (*tlsKeypairReloader, error
 	return result, nil
 }
 
-//NewClientCertPool will load a single client CA
+// NewClientCertPool will load a single client CA
 func NewClientCertPool(clientCaPaths *ClientCAFlags, insecure bool) (*clientCertPool, error) {
 	pool := &clientCertPool{
 		certPaths: clientCaPaths,
@@ -97,7 +97,7 @@ func NewClientCertPool(clientCaPaths *ClientCAFlags, insecure bool) (*clientCert
 	return pool, nil
 }
 
-//Load a certificate into the client CA pool
+// Load a certificate into the client CA pool
 func (pool *clientCertPool) Load() error {
 	if pool.insecure {
 		glog.Infof("can not load client CA pool. Remove --insecure flag to enable.")
@@ -110,7 +110,7 @@ func (pool *clientCertPool) Load() error {
 
 	pool.certPool = x509.NewCertPool()
 	for _, path := range *pool.certPaths {
-		caCertPem, err := ioutil.ReadFile(path)
+		caCertPem, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to load client CA file from path '%s'", path)
 		}
@@ -123,7 +123,7 @@ func (pool *clientCertPool) Load() error {
 	return nil
 }
 
-//GetCertPool returns a client CA pool
+// GetCertPool returns a client CA pool
 func (pool *clientCertPool) GetCertPool() *x509.CertPool {
 	if pool.insecure {
 		return nil
@@ -131,7 +131,7 @@ func (pool *clientCertPool) GetCertPool() *x509.CertPool {
 	return pool.certPool
 }
 
-//GetClientAuth determines the policy the http server will follow for TLS Client Authentication
+// GetClientAuth determines the policy the http server will follow for TLS Client Authentication
 func GetClientAuth(insecure bool) tls.ClientAuthType {
 	if insecure {
 		return tls.NoClientCert

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -15,7 +15,7 @@
 package webhook
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -24,7 +24,7 @@ import (
 )
 
 func TestWebhook(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Webhook Suite")
 }


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Deprecation cleanup and modernization:**

* Replaced `ioutil.WriteFile` with `os.WriteFile` in `writeToFile` function in `pkg/installer/installer.go`.
* Replaced `ioutil.ReadFile` with `os.ReadFile` in `clientCertPool.Load` method in `pkg/webhook/tlsutils.go`.
* Updated test logging to use `io.Discard` instead of `ioutil.Discard` in `pkg/webhook/webhook_suite_test.go`.
* Updated import statements in `pkg/installer/installer.go`, `pkg/webhook/tlsutils.go`, and `pkg/webhook/webhook_suite_test.go` to remove `ioutil` and add `os`/`io` as needed. [[1]](diffhunk://#diff-54d233b6f43cff027b26e07a3882f74072ef3d39eb963dbef699e10b761f8e7fL21) [[2]](diffhunk://#diff-b4737fc796919735b80ac716de965f3665528b7567f58a5d14b0ba2a47f5b683L21-R21) [[3]](diffhunk://#diff-cf396114938533fa35c4edbf8b991be56cd4e8ff523c230d150fe4329625a671L18-R18)

These changes are focused on code maintenance and do not affect application behavior.