### PR TITLE
OCPBUGS-70105: Add kmemane and sanchaud ocp sustaining engineers in owners list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ reviewers:
   - bn222
   - wizhaoredhat
   - SchSeba
+  - kunalmemane
+  - MrSanketKumar
 approvers:
   - zshi-redhat
   - dougbtv
@@ -22,5 +24,7 @@ approvers:
   - bn222
   - wizhaoredhat
   - SchSeba
+  - kunalmemane
+  - MrSanketKumar
 component: "Networking"
 subcomponent: "SR-IOV"


### PR DESCRIPTION
Removed @yash2189 as per the new change in team composition. Added @kunalmemane (kmemane) and @MrSanketkumar (sanchaud) ocp sustaining engineers in owners list of SR-IOV repos.